### PR TITLE
Add GitHub Actions workflow for Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1
+
+    - name: Restore NuGet packages
+      run: nuget restore Voxels.sln
+
+    - name: Install WiX Toolset
+      run: choco install wixtoolset --version 3.11.2 -y
+
+    - name: Build solution
+      run: msbuild Voxels.sln /p:Configuration=Release
+
+    - name: Run tests
+      run: |
+        vstest.console Voxels.Test\\bin\\Release\\Voxels.Test.dll
+
+    - name: Build setup project
+      run: msbuild Voxels.Setup\\Voxels.Setup.wixproj /p:Configuration=Release
+
+    - name: Upload installer
+      uses: actions/upload-artifact@v3
+      with:
+        name: Voxels.Setup
+        path: Voxels.Setup\\bin\\Release\\Voxels.Setup.exe


### PR DESCRIPTION
## Summary
- add Windows GitHub Actions workflow to restore NuGet packages, install WiX, build the solution and setup project, run tests, and upload the installer artifact

## Testing
- `dotnet --version` *(fails: command not found)*
- `nuget` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a7206208331b1f39ea3e19a3747